### PR TITLE
Fix possible API version mismatch between client/daemon

### DIFF
--- a/pylibs/plancton/__init__.py
+++ b/pylibs/plancton/__init__.py
@@ -142,7 +142,7 @@ class Plancton(Daemon):
         """ JSON container settings """
         self._cont_config = None
         """ docker client """
-        self.docker_client = Client(base_url=self.sockpath)
+        self.docker_client = Client(base_url=self.sockpath, version='auto')
         """ Internal status dictionary """
         self._int_st = {
             'system'     : {},


### PR DESCRIPTION
TIL: The parameter `version='auto'` allows to automatically
match API versions of docker client and daemon.

This update should solve the #25 bug.
