### PR TITLE
Fix a missing parenthesis

### DIFF
--- a/pylibs/plancton/__init__.py
+++ b/pylibs/plancton/__init__.py
@@ -413,7 +413,7 @@ class Plancton(Daemon):
                         pid = str(pid)
                     status_table.add_row([num, shortid, status, name, pid ])
 
-        self.logctl.info('\n' + str(status_table)
+        self.logctl.info('\n' + str(status_table))
         return
 
 


### PR DESCRIPTION
A parenthesis was missing in the `__init__.py` code, at line 417
