### PR TITLE
Add wrapper slot in plancton read_conf

### DIFF
--- a/pylibs/plancton/__init__.py
+++ b/pylibs/plancton/__init__.py
@@ -214,10 +214,12 @@ class Plancton(Daemon):
         self._max_docks = int(eval(str(conf.get("max_docks", "ncpus - 2"))))
         self._cpu_shares = self._cpus_per_dock*1024/ncpus
         condor_conf_dict = conf.get("dock_condor_conf", {})
-        self._condor_conf_list = [ 
+        job_wrapper_path = conf.get("parrot_wrapper_path", {})
+        self._container_bind_list = [ 
             condor_conf_dict['condor_common_conf'] + ':/etc/condor/config.d/10-common.config',
             condor_conf_dict['condor_worknode_conf'] + ':/etc/condor/config.d/00-worker.config',
-            condor_conf_dict['condor_base_conf'] + ':/etc/condor/condor_config' ]
+            condor_conf_dict['condor_base_conf'] + ':/etc/condor/condor_config',
+            job_wrapper_path['parrot_wrapper_path' + ':/etc/condor/parrot_job_wrapper.sh'] ]
 
         self._int_st['daemon']['maxcontainers'] = self._max_docks
         self._int_st['daemon']['cputhresh'] = conf.get("cputhresh", "75")
@@ -249,7 +251,7 @@ class Plancton(Daemon):
                                          'Image': self._pilot_dock,
                                          'HostConfig': { 'CpuShares': int(self._cpu_shares),
                                                          'NetworkMode':'bridge',
-                                                         'Binds': self._condor_conf_list,
+                                                         'Binds': self._container_bind_list,
                                                        }
                                         }
         if _apparmor_enabled():


### PR DESCRIPTION
Now plancton should be able to bind the condor wrapper added in [voluntary-config](https://github.com/mconcas/voluntary-config) into plancton worker nodes.
