### PR TITLE
Add drain/resume mode and interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,8 @@ script: |
   ls -l $PIDFILE || true
   sudo test -f $PIDFILE || dielog
   sudo kill -0 $(sudo cat $PIDFILE) || dielog
+  sudo planctonctl drain
+  sleep 40
+  sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
+  sudo planctonctl resume
+  [[ ! -e /var/run/plancton/drain ]]

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -12,22 +12,26 @@ from plancton import Plancton
 
 pidfile = '/var/run/plancton.pid'
 logdir = '/var/log/plancton'
+rundir = '/var/run/plancton'
 confdir = '/etc/plancton'
 
 # Parse command-line arguments
 try:
-  opts, args = getopt(sys.argv[1:], '', [ 'user', 'logdir=', 'pidfile=', 'confdir=' ])
+  opts, args = getopt(sys.argv[1:], '', [ 'user', 'logdir=', 'rundir=', 'pidfile=', 'confdir=' ])
   for o, a in opts:
     if o == '--pidfile':
       pidfile = a
     elif o == '--logdir':
       logdir = a
+    elif o == '--rundir':
+      rundir = a
     elif o == '--confdir':
       confdir = a
     elif o == '--user':
       home = os.path.expanduser('~/.plancton')
       pidfile = '%s/plancton.pid' % home
       logdir = '%s/log' % home
+      rundir = '%s/run' % home
       confdir = '%s/conf' % home
       if not os.path.isdir(home):
         os.mkdir(home, 0700)
@@ -45,10 +49,12 @@ try:
 except IndexError:
   cmd = None
 
-daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir, confdir=confdir)
+daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir,
+                                       rundir=rundir, confdir=confdir)
 
 def help():
-  sys.stderr.write('Usage: %s [start|stop|status|[un]drain|nodaemon|help]\n' % os.path.basename(sys.argv[0]))
+  sys.stderr.write('Usage: %s [start|stop|status|nodaemon|drain|resume|help]\n' % \
+                   os.path.basename(sys.argv[0]))
 
 r = None
 if cmd == 'start':
@@ -58,9 +64,9 @@ elif cmd == 'stop':
 elif cmd == 'status':
   r = daemon_instance.status()
 elif cmd == 'drain':
-  r = daemon_instance.cmd("drain")
-elif cmd == 'undrain':
-  r = daemon_instance.cmd("undrain")
+  r = daemon_instance.drain()
+elif cmd == 'resume':
+  r = daemon_instance.resume()
 elif cmd == 'nodaemon':
   r = daemon_instance.run()
 elif cmd == 'help':

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -48,7 +48,7 @@ except IndexError:
 daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir, confdir=confdir)
 
 def help():
-  sys.stderr.write('Usage: %s [start|stop|status|nodaemon|help]\n' % os.path.basename(sys.argv[0]))
+  sys.stderr.write('Usage: %s [start|stop|status|[un]drain|nodaemon|help]\n' % os.path.basename(sys.argv[0]))
 
 r = None
 if cmd == 'start':
@@ -57,6 +57,10 @@ elif cmd == 'stop':
   r = daemon_instance.stop()
 elif cmd == 'status':
   r = daemon_instance.status()
+elif cmd == 'drain':
+  r = daemon_instance.cmd("drain")
+elif cmd == 'undrain':
+  r = daemon_instance.cmd("undrain")
 elif cmd == 'nodaemon':
   r = daemon_instance.run()
 elif cmd == 'help':

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -103,7 +103,13 @@ class Plancton(Daemon):
    return float(100 - self.efficiency)
 
   # Set daemon name, pidfile, log directory and location of docker socket.
-  def __init__(self, name, pidfile, logdir, confdir, socket_location='unix://var/run/docker.sock'):
+  def __init__(self,
+               name,
+               pidfile,
+               logdir,
+               confdir,
+               socket_url="unix://var/run/docker.sock",
+               drainfile="/var/run/plancton/drain"):
     super(Plancton, self).__init__(name, pidfile)
     self._start_time = self._last_update_time = self._last_confup_time = time.time()
     self._last_kill_time = 0
@@ -111,12 +117,14 @@ class Plancton(Daemon):
     self.uptime0,self.idletime0 = cpu_times()
     self._logdir = logdir
     self._confdir = confdir
-    self.sockpath = socket_location
+    self.sockpath = socket_url
     self._num_cpus = cpu_count()
     self._hostname = gethostname().split('.')[0]
     self._cont_config = None  # container configuration (dict)
     self._container_prefix = "plancton-worker"
-    self.docker_client = Client(base_url=self.sockpath, version='auto')
+    self._drainfile = drainfile
+    self._draindir = os.path.dirname(self._drainfile)
+    self.docker_client = Client(base_url=self.sockpath, version="auto")
     self.conf = {
       "influxdb_url"      : None,             # URL to InfluxDB (with #database)
       "updateconfig"      : 60,               # frequency of config updates (s)
@@ -368,8 +376,37 @@ class Plancton(Daemon):
         else:
           self.logctl.info("Removed container %s", i["Id"])
 
+  def cmd(self, arg=""):
+    if arg is "drain":
+      self.logctl.info("Draining status requested")
+      try:
+        os.open(self._drainfile, os.O_CREAT | os.O_EXCL)
+      except OSError as e:
+        if e.errno == errno.EEXIST:
+          self.logctl.info("Already in draining status")
+        else:
+          self.logctl.warning("There was a problem in creating drainfile: %s" % e)
+      else:
+        self.logctl.info("Entered in draining status")
+
+    elif arg is "undrain":
+      self.logctl.info("Exit from draining status requested")
+      try:
+        os.remove(self._drainfile)
+      except OSError as e:
+        if e.errno == errno.ENOENT:
+          self.logctl.warning("Drainfile not found, skipping...")
+        else:
+          self.logctl.warning("There was a problem in removing drainfile: %s" % e)
+      else:
+        self.logctl.info("Exited from draining status")
+
+    else: # This should not occur
+      self.logctl.warning("Unknown command: %s passed, ignoring..." % arg)
+
+
   def onexit(self):
-    self.logctl.info('Graceful termination requested: will exit gracefully soon.')
+    self.logctl.info('Graceful termination requested: will exit gracefully soon')
     self._do_main_loop = False
     return True
 
@@ -378,6 +415,10 @@ class Plancton(Daemon):
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("docker").setLevel(logging.WARNING)
     self._setup_log_files()
+    if not os.path.isdir(self._draindir):
+      os.mkdir(self._draindir, 0700)
+    else:
+      os.chmod(self._draindir, 0700)
     self._read_conf()
     self._influxdb_setup()
     self.docker_pull(*self.conf["docker_image"].split(":", 1))
@@ -390,6 +431,11 @@ class Plancton(Daemon):
     now = time.time()
     delta_config = now - self._last_confup_time
     delta_update = now - self._last_update_time
+    if os.path.isfile(self._drainfile):
+      self.logctl.info("Drainfile found in %s: drain mode active" % self._drainfile)
+      self.in_drain_mode = True
+    else:
+      self.in_drain_mode = False
     self._overhead_control()
     prev_img = self.conf["docker_image"]
     prev_influxdb_url = self.conf["influxdb_url"]
@@ -409,12 +455,12 @@ class Plancton(Daemon):
     fitting_docks = int(self.idle*0.95*self._num_cpus/(self.conf["cpus_per_dock"]*100))
     launchable_containers = min(fitting_docks, max(self.conf["max_docks"]-running, 0))
     self.logctl.debug('Potentially fitting containers based on CPU utilisation: %d', fitting_docks)
-    if now-self._last_kill_time > self.conf["grace_spawn"]:
+    if now-self._last_kill_time > self.conf["grace_spawn"] and not self.in_drain_mode:
       self.logctl.info('Will launch %d new container(s)' % launchable_containers)
       for _ in range(launchable_containers):
         self._start_container(self._create_container())
     elif launchable_containers > 0:
-      self.logctl.info("Not launching %d containers: too little time elapsed after last kill" % launchable_containers)
+      self.logctl.info("Not launching %d containers: too little time elapsed after last kill or in drain mode" % launchable_containers)
     self._control_containers()
     self._last_update_time = time.time()
     self._dump_container_list()

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -223,6 +223,12 @@ class Daemon(object):
         self.logctl.warning('force-killed')
         return True
 
+    def cmd(self, arg=""):
+      """ Program's cmd function, to be overridden by subclasses.
+          @return True if call succeeds, False otherwise. 
+      """
+      return True
+
     def trapExitSignals(self, func):
         """ Maps exit signals to a function. """
         for s in [ signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT ]:

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -223,12 +223,6 @@ class Daemon(object):
         self.logctl.warning('force-killed')
         return True
 
-    def cmd(self, arg=""):
-      """ Program's cmd function, to be overridden by subclasses.
-          @return True if call succeeds, False otherwise. 
-      """
-      return True
-
     def trapExitSignals(self, func):
         """ Maps exit signals to a function. """
         for s in [ signal.SIGTERM, signal.SIGINT, signal.SIGHUP, signal.SIGQUIT ]:


### PR DESCRIPTION
As decided in #78 (last comment):
 - `planctonctl [un]drain` creates/removes a "placeholder file", (by default in `/var/run/plancton/drain`)
 - Plancton can resume its drain mode on restart
 - `drainfile` can be also removed manually/externally to toggle/untoggle the drain mode