### PR TITLE
Add force-stop option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,5 @@ script: |
   sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
   sudo planctonctl resume
   [[ ! -e /var/run/plancton/drain ]]
+  sudo planctonctl force-stop
+  sudo grep -qi "not starting containers, killing existing" /var/log/plancton/plancton.log || dielog

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -61,6 +61,9 @@ if cmd == 'start':
   r = daemon_instance.start()
 elif cmd == 'stop':
   r = daemon_instance.stop()
+elif cmd == 'force-stop':
+  r = daemon_instance.kill()
+  r = daemon_instance.stop()
 elif cmd == 'status':
   r = daemon_instance.status()
 elif cmd == 'drain':

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -53,7 +53,7 @@ daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir,
                                        rundir=rundir, confdir=confdir)
 
 def help():
-  sys.stderr.write('Usage: %s [start|stop|status|nodaemon|drain|resume|help]\n' % \
+  sys.stderr.write('usage: %s [start|stop|force-stop|status|nodaemon|drain|resume|help]\n' % \
                    os.path.basename(sys.argv[0]))
 
 r = None

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -71,7 +71,7 @@ elif cmd == 'drain':
 elif cmd == 'resume':
   r = daemon_instance.resume()
 elif cmd == 'nodaemon':
-  r = daemon_instance.run()
+  r = daemon_instance.runForeground()
 elif cmd == 'help':
   help()
   r = True

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -402,7 +402,7 @@ class Plancton(Daemon):
         self.logctl.warning("Cannot remove drain status file %s: %s" % (self._drainfile, e))
 
   def kill(self):
-    self.logctl.info("Force-stop mode requested: no new containers started")
+    self.logctl.info("Force-stop mode requested: not starting new containers and killing running ones")
     try:
       os.open(self._fstopfile, os.O_CREAT|os.O_EXCL)
     except OSError as e:
@@ -416,10 +416,14 @@ class Plancton(Daemon):
     self._do_main_loop = False
 
   def init(self):
-    self.logctl.info("---- plancton daemon v%s ----" % self.__version__)
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("docker").setLevel(logging.WARNING)
     self._setup_log_files()
+    self.logctl.info("---- plancton v%s running with pid %d ----" % (self.__version__, os.getpid()))
+    try:
+      os.remove(self._fstopfile)
+    except OSError as e:
+      pass
     if not os.path.isdir(self._rundir):
       os.mkdir(self._rundir, 0700)
     else:

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -119,7 +119,7 @@ class Plancton(Daemon):
     self._cont_config = None  # container configuration (dict)
     self._container_prefix = "plancton-worker"
     self._drainfile = self._rundir + "/drain"
-    self._fstopfile = self._rundir + "/fstopfile"
+    self._fstopfile = self._rundir + "/force-stop"
     self._force_kill = False
     self.docker_client = Client(base_url=self.sockpath, version="auto")
     self.conf = {
@@ -332,9 +332,8 @@ class Plancton(Daemon):
           dock_uptime = utc_time() - time.mktime(statobj.timetuple())
           if dock_uptime > self.conf["max_ttl"] or self._force_kill:
             if self._force_kill:
-              self.logctl.info("Force-killing %s ", i['Id'])
-            else:
-              self.logctl.info("Killing %s since it exceeded the max TTL", i['Id'])
+              self.logctl.info("Force killing %s" if self._force_kill else \
+                               "Killing %s since it exceeded the max TTL", i['Id'])
             self.streamer(series="container",
                           tags={ "hostname": self._hostname,
                                  "started": True,

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -411,13 +411,8 @@ class Plancton(Daemon):
     return True
 
   def onexit(self):
-    if os.path.isfile(self._fstopfile):
-      self.logctl.info("Waiting for the cleanup of running containers: will gracefully exit later on.")
-      return False
-    else:
-      self.logctl.info("Graceful termination requested: will exit gracefully soon")
-      self._do_main_loop = False
-      return True
+    self.logctl.info("Graceful termination requested: will exit gracefully soon")
+    self._do_main_loop = False
 
   def init(self):
     self.logctl.info("---- plancton daemon v%s ----" % self.__version__)

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -478,9 +478,10 @@ class Plancton(Daemon):
       count = 0
       self.main_loop()
       self.logctl.debug("Sleeping %d seconds..." % self.conf["main_sleep"])
-      while (self._do_main_loop or self._force_kill) and count < self.conf["main_sleep"]:
+      self._force_kill = os.path.isfile(self._fstopfile)
+      while self._do_main_loop and count < self.conf["main_sleep"] and not self._force_kill:
         time.sleep(1)
         count = count+1
-      self._force_kill = os.path.isfile(self._fstopfile)
-    self.logctl.info("Exiting gracefully.")
+        self._force_kill = os.path.isfile(self._fstopfile)
+    self.logctl.info("Exiting gracefully")
     return 0

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -121,6 +121,7 @@ class Plancton(Daemon):
     self._drainfile = self._rundir + "/drain"
     self._fstopfile = self._rundir + "/force-stop"
     self._force_kill = False
+    self._do_main_loop = True
     self.docker_client = Client(base_url=self.sockpath, version="auto")
     self.conf = {
       "influxdb_url"      : None,             # URL to InfluxDB (with #database)
@@ -427,7 +428,6 @@ class Plancton(Daemon):
     self._influxdb_setup()
     self.docker_pull(*self.conf["docker_image"].split(":", 1))
     self._control_containers()
-    self._do_main_loop = True
 
   # Main loop, do comparison between uptime and thresholds sets for updates.
   def main_loop(self):

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -187,7 +187,6 @@ class Daemon(object):
             If the daemon is still running after this termination attempt, **signal 9 (KILL)** is sent, and
             daemon is abruptly terminated.
             Note that this attempt might fail as well.
-            If a `cmd` is specified, it will run self.cmd(arg=cmd) method before anything else.
             @return True on success, where "success" means that the final status is that the daemon is not
             running: an example of success is when the daemon wasn't running and `stop()` is
             called. False is returned otherwise.

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -173,10 +173,10 @@ class Daemon(object):
         """
         self.readPid()
         if self.isRunning():
-            self.logctl.info('Running with PID %d' % self.pid)
+            self.logctl.info('running with PID %d' % self.pid)
             return True
         else:
-            self.logctl.info('Not running')
+            self.logctl.info('not running')
             return False
 
     def stop(self):

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -173,10 +173,10 @@ class Daemon(object):
         """
         self.readPid()
         if self.isRunning():
-            self.logctl.info('running with PID %d' % self.pid)
+            self.logctl.info('Running with PID %d' % self.pid)
             return True
         else:
-            self.logctl.info('not running')
+            self.logctl.info('Not running')
             return False
 
     def stop(self):

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -187,12 +187,13 @@ class Daemon(object):
             If the daemon is still running after this termination attempt, **signal 9 (KILL)** is sent, and
             daemon is abruptly terminated.
             Note that this attempt might fail as well.
+            If a `cmd` is specified, it will run self.cmd(arg=cmd) method before anything else.
             @return True on success, where "success" means that the final status is that the daemon is not
             running: an example of success is when the daemon wasn't running and `stop()` is
             called. False is returned otherwise.
         """
-
         self.logctl.info('stopping, this may take a while...')
+
         # Get the pid from the pidfile
         self.readPid()
         if not self.isRunning():

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -241,20 +241,22 @@ class Daemon(object):
             and the mapping is restored in case exiting is cancelled.
         """
         self.trapExitSignals(self.exitHandlerNoOp)
-        if self.onexit():
-            # Exit was confirmed
-            sys.exit(0)
-        else:
-            # Exit was cancelled
-            self.trapExitSignals(self.exitHandlerReal)
+        self.onexit()
+        self.trapExitSignals(self.exitHandlerReal)
 
     def onexit(self):
         """ Program's exit function, to be overridden by subclasses.
             This function is called when an exit signal is caught: it should be used to implement cleanup
             functions.
-            @return When returning True, exiting continues, when returning False exiting is cancelled
         """
-        return True
+        pass
+
+    def runForeground(self):
+      self.trapExitSignals(self.exitHandlerReal)
+      try:
+        self.run()
+      except KeyboardInterrupt:
+        self.onexit()
 
     def run(self):
         """ Program's main loop, to be overridden by subclasses.


### PR DESCRIPTION
It will:
 - create a _placeholder_ in `self._rundir+'/fstopfile'`
 - trigger `main_loop` to raise a flag if it founds such a _ph_
 - switch `control_containers()` in a `killall` version: it kills every owned+running container
 - wait for the cleanup, by returning `False` from every `onexit()` call that finds _ph_ still there
 - remove the _placeholder_ in the `control_container()` scope, NOT on upon a successful `onexit()` call