### PR TITLE
No timeout on force-stop

### DIFF
--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -63,10 +63,10 @@ elif cmd == 'force-start':
   r = daemon_instance.resume()
   r = daemon_instance.start()
 elif cmd == 'stop':
-  r = daemon_instance.stop()
+  r = daemon_instance.stop(no_timeout=False)
 elif cmd == 'force-stop':
   r = daemon_instance.kill()
-  r = daemon_instance.stop()
+  r = daemon_instance.stop(no_timeout=True)
 elif cmd == 'status':
   r = daemon_instance.status()
 elif cmd == 'drain':

--- a/plancton/daemon.py
+++ b/plancton/daemon.py
@@ -179,7 +179,7 @@ class Daemon(object):
             self.logctl.info('Not running')
             return False
 
-    def stop(self):
+    def stop(self, no_timeout=False):
         """ Stop the daemon.
             An attempt to kill the daemon is performed for 30 seconds sending **signal 15 (SIGTERM)**: if
             the daemon is implemented properly, it will perform its shutdown operations and it will exit
@@ -200,9 +200,9 @@ class Daemon(object):
             return True
         # Try killing the daemon process gracefully
         kill_count = 0
-        kill_count_threshold = 60
+        kill_count_threshold = 120
         try:
-            while kill_count < kill_count_threshold:
+            while no_timeout or kill_count < kill_count_threshold:
                 os.kill(self.pid, signal.SIGTERM)
                 time.sleep(1)
                 kill_count = kill_count + 1


### PR DESCRIPTION
Makes sure Plancton does not exit until there are containers still running.