### PR TITLE
Add drain-kill command to planctonctl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script: |
   ls -l $PIDFILE || true
   sudo test -f $PIDFILE || dielog
   sudo kill -0 $(sudo cat $PIDFILE) || dielog
-  sudo planctonctl drain-kill
+  sudo planctonctl drain-stop
   sudo test -f /var/run/plancton/drain || dielog
   sleep 40
   sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,28 +15,31 @@ install: |
 script: |
   set -ex
   PIDFILE=/var/run/plancton.pid
+  LOGFILE=/var/log/plancton/plancton.log
+  DRAINFILE=/var/run/plancton/drain
+  STOPFILE=/var/run/plancton/stop
   dielog() {
-    sudo cat /var/log/plancton/plancton.log
+    sudo cat $LOGFILE
     return 1
   }
   ls -l $PIDFILE || true
   sudo test -f $PIDFILE || dielog
   sudo kill -0 $(sudo cat $PIDFILE) || dielog
   sudo planctonctl drain
-  sudo test -f /var/run/plancton/drain || dielog
+  sudo test -f $DRAINFILE || dielog
   sleep 40
-  sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
+  sudo grep -qi "no new containers will be started" $LOGFILE || dielog
   sudo planctonctl resume
-  ! sudo test -f /var/run/plancton/drain || dielog
+  ! sudo test -f $DRAINFILE || dielog
   sudo planctonctl force-stop
-  sudo grep -qi "not starting containers, killing existing" /var/log/plancton/plancton.log || dielog
+  sudo grep -qi "not starting containers, killing existing" $LOGFILE || dielog
   sudo planctonctl start
   ls -l $PIDFILE || true
   sudo test -f $PIDFILE || dielog
   sudo kill -0 $(sudo cat $PIDFILE) || dielog
   sudo planctonctl drain-stop
-  sudo test -f /var/run/plancton/drain || dielog
+  sudo test -f $DRAINFILE || dielog
   sleep 40
-  sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
-  sudo grep -qi "drain-kill mode requested" /var/log/plancton/plancton.log || dielog
-  sudo test -f /var/run/plancton/drain && ! sudo test -f /var/run/plancton/kill || dielog
+  sudo grep -qi "no new containers will be started" $LOGFILE || dielog
+  sudo grep -qi "drain-stop requested" $LOGFILE || dielog
+  sudo test -f $DRAINFILE && ! sudo test -f $STOPFILE || dielog/LOGFILE

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,20 @@ script: |
   sudo test -f $PIDFILE || dielog
   sudo kill -0 $(sudo cat $PIDFILE) || dielog
   sudo planctonctl drain
+  sudo test -f /var/run/plancton/drain || dielog
   sleep 40
   sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
   sudo planctonctl resume
-  [[ ! -e /var/run/plancton/drain ]]
+  ! sudo test -f /var/run/plancton/drain || dielog
   sudo planctonctl force-stop
   sudo grep -qi "not starting containers, killing existing" /var/log/plancton/plancton.log || dielog
+  sudo planctonctl start
+  ls -l $PIDFILE || true
+  sudo test -f $PIDFILE || dielog
+  sudo kill -0 $(sudo cat $PIDFILE) || dielog
+  sudo planctonctl drain-kill
+  sudo test -f /var/run/plancton/drain || dielog
+  sleep 40
+  sudo grep -qi "no new containers will be started" /var/log/plancton/plancton.log || dielog
+  sudo grep -qi "drain-kill mode requested" /var/log/plancton/plancton.log || dielog
+  sudo test -f /var/run/plancton/drain && ! sudo test -f /var/run/plancton/kill || dielog

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -53,7 +53,7 @@ daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir,
                                        rundir=rundir, confdir=confdir)
 
 def help():
-  sys.stderr.write('usage: %s [start|force-start|stop|force-stop|status|nodaemon|drain|drain-kill|resume|help]\n' % \
+  sys.stderr.write('usage: %s [start|force-start|stop|force-stop|status|nodaemon|drain|drain-stop|resume|help]\n' % \
                    os.path.basename(sys.argv[0]))
 
 r = None
@@ -71,7 +71,7 @@ elif cmd == 'status':
   r = daemon_instance.status()
 elif cmd == 'drain':
   r = daemon_instance.drain()
-elif cmd == 'drain-kill':
+elif cmd == 'drain-stop':
   r = daemon_instance.drain(kill=True)
 elif cmd == 'resume':
   r = daemon_instance.resume()

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -53,7 +53,7 @@ daemon_instance = Plancton('plancton', pidfile=pidfile, logdir=logdir,
                                        rundir=rundir, confdir=confdir)
 
 def help():
-  sys.stderr.write('usage: %s [start|force-start|stop|force-stop|status|nodaemon|drain|resume|help]\n' % \
+  sys.stderr.write('usage: %s [start|force-start|stop|force-stop|status|nodaemon|drain|drain-kill|resume|help]\n' % \
                    os.path.basename(sys.argv[0]))
 
 r = None
@@ -71,6 +71,8 @@ elif cmd == 'status':
   r = daemon_instance.status()
 elif cmd == 'drain':
   r = daemon_instance.drain()
+elif cmd == 'drain-kill':
+  r = daemon_instance.drain(kill=True)
 elif cmd == 'resume':
   r = daemon_instance.resume()
 elif cmd == 'nodaemon':

--- a/bin/planctonctl
+++ b/bin/planctonctl
@@ -72,7 +72,7 @@ elif cmd == 'status':
 elif cmd == 'drain':
   r = daemon_instance.drain()
 elif cmd == 'drain-stop':
-  r = daemon_instance.drain(kill=True)
+  r = daemon_instance.drain(stop=True)
 elif cmd == 'resume':
   r = daemon_instance.resume()
 elif cmd == 'nodaemon':

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -391,11 +391,13 @@ class Plancton(Daemon):
           self.logctl.error("Cannot remove force-stop status file %s: %s" % (self._fstopfile, e))
 
   def drain(self, kill=False):
-    self.logctl.info("Drain mode requested: no new containers started")
     try:
       os.open(self._drainfile, os.O_CREAT|os.O_EXCL)
       if kill:
+        self.logctl.info("Drain-kill mode requested, no new containers started, will exit afterwards")
         os.open(self._drainfile_kill, os.O_CREAT|os.O_EXCL)
+      else:
+        self.logctl.info("Drain mode requested, no new containers started")
     except OSError as e:
       if e.errno != errno.EEXIST:
         self.logctl.error("Cannot create drain/drain-kill status file(s) %s" % e)
@@ -492,7 +494,7 @@ class Plancton(Daemon):
     if running == 0 and draining and os.path.isfile(self._drainfile_kill):
       self.logctl.info("Drain-kill mode requested. No running containers found, will exit.")
       os.remove(self._drainfile_kill)
-      onexit()
+      self.onexit()
 
 
   # Main daemon function. Return is in the range 0-255.


### PR DESCRIPTION
Usage: `planctonctl drain-kill`
This command will:
 - create two placeholders: the `drain` one, used for draining and a `kill` one, used to
   terminate the instance whe it find zero running containers in drain mode
 - make the main loop delete the `kill` file in the previous mentioned scenario
   before exiting