### PR TITLE
Multi influx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,12 +74,13 @@ script: |
     ! $MODE test -f $PIDFILE || dielog
 
     # Test Plancton multi-streaming
-    $MODE mkdir -p $CONFDIR/conf
-    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/conf/config.yaml                                                                                   done
+    $MODE mkdir -p $CONFDIR
+    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/config.yaml
     for i in {1..3}; do
       echo "  - http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2 | tee -a ports)#plancton-monitor" |\
-        $MODE tee -a $CONFDIR/conf/config.yaml
+        $MODE tee -a $CONFDIR/config.yaml
     done
+
     $MODE planctonctl --confdir $CONFDIR start
     sleep 60
     for i in $(cat ports); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,21 +76,21 @@ script: |
     # Test Plancton multi-streaming
     $MODE rm -f $DRAINFILE || true
     $MODE mkdir -p $CONFDIR
-    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/config.yaml
-    for i in {1..3}; do
-      echo "  - http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2 | tee -a ports)#plancton-monitor" |\
+    echo "influxdb_url:" | $MODE tee $CONFDIR/config.yaml
+    for I in {1..2}; do
+      echo "- http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d: -f2 | tee -a influxdb_ports)#plancton-monitor" | \
         $MODE tee -a $CONFDIR/config.yaml
     done
 
     $MODE planctonctl --confdir=$CONFDIR start
     sleep 60
-    for i in $(cat ports); do
-      GOOD_RET_VAL=$(curl -s http://0.0.0.0:$i/query?pretty=true --data db=plancton-monitor --data-urlencode 'q=SELECT COUNT(*) FROM "measurement"' |\
+    for PORT in $(cat influxdb_ports); do
+      OUT=$(curl -s http://0.0.0.0:$PORT/query?pretty=true --data db=plancton-monitor --data-urlencode 'q=SELECT COUNT(*) FROM "measurement"' | \
         jq '.results[0].series[0].values[0][1]')
-      [[ "$GOOD_RET_VAL" -gt "0" ]] && echo "Test good query ($i) -> success" || dielog
-      BAD_RET_VAL=$(curl -s http://0.0.0.0:$i/query?pretty=true --data db=plancton-monitorBAD --data-urlencode 'q=SELECT COUNT(*) FROM "measuentBAD"' |\
+      [[ $OUT -gt 0 ]] || { echo "ERROR: InfluxDB good query on port $PORT returned $OUT"; dielog; }
+      OUT=$(curl -s http://0.0.0.0:$PORT/query?pretty=true --data db=plancton-monitor-nope --data-urlencode 'q=SELECT COUNT(*) FROM "measurement"' | \
         jq '.results[0].series[0].values[0][1]')
-      [[ "$BAD_RET_VAL" == "null" ]] && echo "Test bad query ($i) -> success" || dielog
+      [[ $OUT == null ]] || { echo "ERROR: InfluxDB bad query on port $PORT returned $OUT"; dielog; }
     done
-    $MODE rm -f ports
+    $MODE rm -f influxdb_ports
   done

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,20 @@ script: |
       sudo)   PIDFILE=/var/run/plancton.pid
               LOGFILE=/var/log/plancton/plancton.log
               DRAINFILE=/var/run/plancton/drain
-              STOPFILE=/var/run/plancton/stop ;;
+              STOPFILE=/var/run/plancton/stop
+              CONFIGFILE=/etc/plancton/config.yaml ;;
       nosudo) PIDFILE=$HOME/.plancton/run/plancton.pid
               LOGFILE=$HOME/.plancton/log/plancton.log
               DRAINFILE=$HOME/.plancton/run/drain
-              STOPFILE=$HOME/.plancton/run/stop ;;
+              STOPFILE=$HOME/.plancton/run/stop
+              CONFIGFILE=$HOME/.plancton/config.yaml;;
     esac
+
+    # Create databases and configuration
+    $MODE echo -e "---\ninfluxdb_url:" > $CONFIGFILE
+    for i in {1..3}; do
+      $MODE echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" >> $CONFIGFILE
+    done
 
     # Test Plancton startup
     $MODE planctonctl start

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ script: |
               LOGFILE=/var/log/plancton/plancton.log
               DRAINFILE=/var/run/plancton/drain
               STOPFILE=/var/run/plancton/stop
-              CONFDIR=/var/run/plancton ;;
+              CONFDIR=/var/run/plancton/conf ;;
       nosudo) PIDFILE=$HOME/.plancton/run/plancton.pid
               LOGFILE=$HOME/.plancton/log/plancton.log
               DRAINFILE=$HOME/.plancton/run/drain
               STOPFILE=$HOME/.plancton/run/stop
-              CONFDIR=$HOME/.plancton/run ;;
+              CONFDIR=$HOME/.plancton/run/conf ;;
     esac
 
     # Test Plancton startup
-    $MODE planctonctl --confdir $CONFDIR start
+    $MODE planctonctl start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
 
@@ -58,7 +58,7 @@ script: |
     $MODE grep -qi "not starting containers, killing existing" $LOGFILE || dielog
 
     # Test Plancton drain and then stop mode
-    $MODE planctonctl --confdir $CONFDIR start
+    $MODE planctonctl start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
     $MODE planctonctl drain-stop
@@ -82,7 +82,7 @@ script: |
         $MODE tee -a $CONFDIR/config.yaml
     done
 
-    $MODE planctonctl --confdir $CONFDIR start
+    $MODE planctonctl --confdir=$CONFDIR start
     sleep 60
     for i in $(cat ports); do
       GOOD_RET_VAL=$(curl -s http://0.0.0.0:$i/query?pretty=true --data db=plancton-monitor --data-urlencode 'q=SELECT COUNT(*) FROM "measurement"' |\

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,22 +27,23 @@ script: |
               LOGFILE=/var/log/plancton/plancton.log
               DRAINFILE=/var/run/plancton/drain
               STOPFILE=/var/run/plancton/stop
-              CONFIGFILE=/var/run/plancton/config.yaml ;;
+              CONFDIR=/var/run/plancton ;;
       nosudo) PIDFILE=$HOME/.plancton/run/plancton.pid
               LOGFILE=$HOME/.plancton/log/plancton.log
               DRAINFILE=$HOME/.plancton/run/drain
               STOPFILE=$HOME/.plancton/run/stop
-              CONFIGFILE=$HOME/.plancton/run/config.yaml;;
+              CONFDIR=$HOME/.plancton/run ;;
     esac
 
     # Create databases and configuration
-    $MODE echo -e "---\ninfluxdb_url:" > $CONFIGFILE
+    $MODE mkdir -p $CONFDIR/conf
+    $MODE echo -e "---\ninfluxdb_url:" > $CONFDIR/conf/config.yaml
     for i in {1..3}; do
-      $MODE echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" >> $CONFIGFILE
+      $MODE echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" >> $CONFDIR/conf/config.yaml
     done
 
     # Test Plancton startup
-    $MODE planctonctl --confidr $CONFIGFILE start
+    $MODE planctonctl --confidr $CONFDIR start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
 
@@ -61,7 +62,7 @@ script: |
     $MODE grep -qi "not starting containers, killing existing" $LOGFILE || dielog
 
     # Test Plancton drain and then stop mode
-    $MODE planctonctl --confidr $CONFIGFILE start
+    $MODE planctonctl --confidr $CONFDIR start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
     $MODE planctonctl drain-stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ script: |
     ! $MODE test -f $PIDFILE || dielog
 
     # Test Plancton multi-streaming
+    $MODE rm -f $DRAINFILE
     $MODE mkdir -p $CONFDIR
     echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/config.yaml
     for i in {1..3}; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script: |
     ! $MODE test -f $PIDFILE || dielog
 
     # Test Plancton multi-streaming
-    $MODE rm -f $DRAINFILE
+    $MODE rm -f $DRAINFILE || true
     $MODE mkdir -p $CONFDIR
     echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/config.yaml
     for i in {1..3}; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script: |
               LOGFILE=$HOME/.plancton/log/plancton.log
               DRAINFILE=$HOME/.plancton/run/drain
               STOPFILE=$HOME/.plancton/run/stop
-              CONFDIR=$HOME/.plancton/run/conf ;;
+              CONFDIR=$HOME/.plancton/conf ;;
     esac
 
     # Test Plancton startup

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ script: |
 
     # Create databases and configuration
     $MODE mkdir -p $CONFDIR/conf
-    $MODE echo -e "---\ninfluxdb_url:" > $CONFDIR/conf/config.yaml
+    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/conf/config.yaml
     for i in {1..3}; do
-      $MODE echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" >> $CONFDIR/conf/config.yaml
+      echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" | $MODE tee -a $CONFDIR/conf/config.yaml
     done
 
     # Test Plancton startup

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ script: |
     done
 
     # Test Plancton startup
-    $MODE planctonctl --confidr $CONFDIR start
+    $MODE planctonctl --confdir $CONFDIR start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
 
@@ -62,7 +62,7 @@ script: |
     $MODE grep -qi "not starting containers, killing existing" $LOGFILE || dielog
 
     # Test Plancton drain and then stop mode
-    $MODE planctonctl --confidr $CONFDIR start
+    $MODE planctonctl --confdir $CONFDIR start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
     $MODE planctonctl drain-stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ script: |
               LOGFILE=/var/log/plancton/plancton.log
               DRAINFILE=/var/run/plancton/drain
               STOPFILE=/var/run/plancton/stop
-              CONFIGFILE=/etc/plancton/config.yaml ;;
+              CONFIGFILE=/var/run/plancton/config.yaml ;;
       nosudo) PIDFILE=$HOME/.plancton/run/plancton.pid
               LOGFILE=$HOME/.plancton/log/plancton.log
               DRAINFILE=$HOME/.plancton/run/drain
               STOPFILE=$HOME/.plancton/run/stop
-              CONFIGFILE=$HOME/.plancton/config.yaml;;
+              CONFIGFILE=$HOME/.plancton/run/config.yaml;;
     esac
 
     # Create databases and configuration
@@ -42,7 +42,7 @@ script: |
     done
 
     # Test Plancton startup
-    $MODE planctonctl start
+    $MODE planctonctl --confidr $CONFIGFILE start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
 
@@ -61,7 +61,7 @@ script: |
     $MODE grep -qi "not starting containers, killing existing" $LOGFILE || dielog
 
     # Test Plancton drain and then stop mode
-    $MODE planctonctl start
+    $MODE planctonctl --confidr $CONFIGFILE start
     $MODE test -f $PIDFILE || dielog
     $MODE kill -0 $($MODE cat $PIDFILE) || dielog
     $MODE planctonctl drain-stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install: |
   set -x
   git rev-parse HEAD
   sudo pip install -e .
-  sudo plancton-bootstrap mconcas/plancton-conf:travis-test
 
 script: |
   set -ex

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ services:
 
 language: python
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y jq
+
 install: |
   set -x
   git rev-parse HEAD
@@ -33,13 +37,6 @@ script: |
               STOPFILE=$HOME/.plancton/run/stop
               CONFDIR=$HOME/.plancton/run ;;
     esac
-
-    # Create databases and configuration
-    $MODE mkdir -p $CONFDIR/conf
-    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/conf/config.yaml
-    for i in {1..3}; do
-      echo "  - http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" | $MODE tee -a $CONFDIR/conf/config.yaml
-    done
 
     # Test Plancton startup
     $MODE planctonctl --confdir $CONFDIR start
@@ -75,4 +72,23 @@ script: |
     # Test Plancton stop
     $MODE planctonctl stop
     ! $MODE test -f $PIDFILE || dielog
+
+    # Test Plancton multi-streaming
+    $MODE mkdir -p $CONFDIR/conf
+    echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/conf/config.yaml                                                                                   done
+    for i in {1..3}; do
+      echo "  - http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2 | tee -a ports)#plancton-monitor" |\
+        $MODE tee -a $CONFDIR/conf/config.yaml
+    done
+    $MODE planctonctl --confdir $CONFDIR start
+    sleep 60
+    for i in $(cat ports); do
+      GOOD_RET_VAL=$(curl -s http://0.0.0.0:$i/query?pretty=true --data db=plancton-monitor --data-urlencode 'q=SELECT COUNT(*) FROM "measurement"' |\
+        jq '.results[0].series[0].values[0][1]')
+      [[ "$GOOD_RET_VAL" -gt "0" ]] && echo "Test good query ($i) -> success" || dielog
+      BAD_RET_VAL=$(curl -s http://0.0.0.0:$i/query?pretty=true --data db=plancton-monitorBAD --data-urlencode 'q=SELECT COUNT(*) FROM "measuentBAD"' |\
+        jq '.results[0].series[0].values[0][1]')
+      [[ "$BAD_RET_VAL" == "null" ]] && echo "Test bad query ($i) -> success" || dielog
+    done
+    $MODE rm -f ports
   done

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script: |
     $MODE mkdir -p $CONFDIR/conf
     echo -e "---\ninfluxdb_url:" | $MODE tee $CONFDIR/conf/config.yaml
     for i in {1..3}; do
-      echo "  - http://locahost:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" | $MODE tee -a $CONFDIR/conf/config.yaml
+      echo "  - http://0.0.0.0:$(docker run -d -P influxdb | xargs docker port | awk '{print $3}' | cut -d':' -f2)#plancton-monitor" | $MODE tee -a $CONFDIR/conf/config.yaml
     done
 
     # Test Plancton startup

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -218,15 +218,12 @@ class Plancton(Daemon):
       self.conf["influxdb_url"] = {x for x in self.conf["influxdb_url"] and "#" in x}
     else:
       self.conf["influxdb_url"] = set()
-    self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2))
+    # self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2))
 
   # Set up monitoring target.
   def _influxdb_setup(self):
     for url in self.conf["influxdb_url"]:
       self.streamers.add(InfluxDBStreamer(**dict(zip(["baseurl", "database"], url.split("#", 1)))))
-  #   self.streamers = [InfluxDBStreamer(baseurl=url.split("#")[0], database=url.split("#")[1]) \
-  #     for url in self.conf["influxdb_url"] and not (url.split("#")[0], url.split("#")[1]) in [(k.baseurl, k.database) for k in self.streamers]]
-  #   self.streamers = [x for x in self.streamers if (x.baseurl, x.database) in [(url.split("#")[0], url.split("#")[1]) for url in self.conf["influxdb_url"]]]
 
   # Efficiency is calculated subtracting idletime per cpu from uptime.
   def _set_cpu_efficiency(self):

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -42,11 +42,6 @@ def cpu_times():
 def utc_time():
   return time.mktime(datetime.utcnow().timetuple())
 
-def set_default(obj):
-    if isinstance(obj, set):
-        return list(obj)
-    raise TypeError
-
 # Wrap API calls and catch exceptions to provide "robustness"
 def robust(tries=5, delay=3, backoff=2):
   def robust_decorator(f):
@@ -223,7 +218,7 @@ class Plancton(Daemon):
         self.conf["influxdb_url"] = set(filter(lambda x: "#" in x, self.conf["influxdb_url"]))
       else:
         self.conf["influxdb_url"] = set()
-    self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2, default=set_default))
+    self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2, default=list(x)))
 
   # Set up monitoring target.
   def _influxdb_setup(self):

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -221,6 +221,7 @@ class Plancton(Daemon):
 
   # Set up monitoring target.
   def _influxdb_setup(self):
+    self.streamers = set()
     for url in self.conf["influxdb_url"]:
       self.streamers.add(InfluxDBStreamer(**dict(zip(["baseurl", "database"], url.split("#", 1)))))
 

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -138,7 +138,7 @@ class Plancton(Daemon):
     self.streamers = set()
     self.docker_client = Lazy(lambda: Client(base_url=self._sockpath, version="auto"))
     self.conf = {
-      "influxdb_url"      : [],               # URL list to InfluxDB (with #database)
+      "influxdb_url"      : set(),            # URL set to InfluxDB (with #database)
       "updateconfig"      : 60,               # frequency of config updates (s)
       "image_expiration"  : 43200,            # frequency of image updates (s)
       "main_sleep"        : 30,               # main loop sleep (s)
@@ -212,12 +212,11 @@ class Plancton(Daemon):
     if not isinstance(self.conf["docker_cmd"], list):
       self.conf["docker_cmd"] = self.conf["docker_cmd"].split(" ")
     if isinstance(self.conf["influxdb_url"], str):
-      self.conf["influxdb_url"] = set(self.conf["influxdb_url"])
+      self.conf["influxdb_url"] = set([self.conf["influxdb_url"]])
+    elif isinstance(self.conf["influxdb_url"], list):
+      self.conf["influxdb_url"] = set(filter(lambda x: "#" in x, self.conf["influxdb_url"]))
     else:
-      if isinstance(self.conf["influxdb_url"], list):
-        self.conf["influxdb_url"] = set(filter(lambda x: "#" in x, self.conf["influxdb_url"]))
-      else:
-        self.conf["influxdb_url"] = set()
+      self.conf["influxdb_url"] = set()
     self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2, default=list))
 
   # Set up monitoring target.

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -218,15 +218,10 @@ class Plancton(Daemon):
   # Set up monitoring target.
   def _influxdb_setup(self):
     self.streamers = []
-    if not self.conf["influxdb_url"]:
-      self.streamers.append(lambda *x,**y: True)
-      return
-    if isinstance(self.conf["influxdb_url"], list):
-      for i,j in enumerate(self.conf["influxdb_url"]):
-        baseurl,db = self.conf["influxdb_url"][j].split("#")
-        self.streamers.append(InfluxDBStreamer(baseurl=baseurl, database=db))
-    else:
-      baseurl,db = self.conf["influxdb_url"].split("#")
+    if not isinstance(self.conf["influxdb_url"], list):
+      self.conf["influxdb_url"] = [ self.conf["influxdb_url"] ]
+    for url in self.conf["influxdb_url"]:
+      baseurl,db = url.split("#")
       self.streamers.append(InfluxDBStreamer(baseurl=baseurl, database=db))
 
   # Efficiency is calculated subtracting idletime per cpu from uptime.

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -218,7 +218,7 @@ class Plancton(Daemon):
         self.conf["influxdb_url"] = set(filter(lambda x: "#" in x, self.conf["influxdb_url"]))
       else:
         self.conf["influxdb_url"] = set()
-    self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2, default=list(x)))
+    self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2, default=list))
 
   # Set up monitoring target.
   def _influxdb_setup(self):

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -135,9 +135,10 @@ class Plancton(Daemon):
     self._force_kill = False
     self._do_main_loop = True
     self._has_image = False
+    self.streamers = []
     self.docker_client = Lazy(lambda: Client(base_url=self._sockpath, version="auto"))
     self.conf = {
-      "influxdb_url"      : None,             # URL to InfluxDB (with #database)
+      "influxdb_url"      : [],               # URL list to InfluxDB (with #database)
       "updateconfig"      : 60,               # frequency of config updates (s)
       "image_expiration"  : 43200,            # frequency of image updates (s)
       "main_sleep"        : 30,               # main loop sleep (s)
@@ -210,19 +211,19 @@ class Plancton(Daemon):
       self.conf["max_docks"] = 0
     if not isinstance(self.conf["docker_cmd"], list):
       self.conf["docker_cmd"] = self.conf["docker_cmd"].split(" ")
-    if self.conf["influxdb_url"] and not "#" in self.conf["influxdb_url"]:
-      # Invalid InfluxDB URL: disable monitoring
-      self.conf["influxdb_url"] = None
+    tmp_url_list = []
+    if isinstance(self.conf["influxdb_url"], str):
+      self.conf["influxdb_url"] = [ self.conf["influxdb_url"] ]
+    if isinstance(self.conf["influxdb_url"], list):
+      tmp_url_list = [x for x in self.conf["influxdb_url"] and "#" in x]
+    self.conf["influxdb_url"] = tmp_url_list
     self.logctl.debug("Configuration:\n%s" % json.dumps(self.conf, indent=2))
 
   # Set up monitoring target.
   def _influxdb_setup(self):
-    self.streamers = []
-    if not isinstance(self.conf["influxdb_url"], list):
-      self.conf["influxdb_url"] = [ self.conf["influxdb_url"] ]
-    for url in self.conf["influxdb_url"]:
-      baseurl,db = url.split("#")
-      self.streamers.append(InfluxDBStreamer(baseurl=baseurl, database=db))
+    self.streamers = [InfluxDBStreamer(baseurl=url.split("#")[0], database=url.split("#")[1]) \
+      for url in self.conf["influxdb_url"] and not (url.split("#")[0], url.split("#")[1]) in [(k.baseurl, k.database) for k in self.streamers]]
+    self.streamers = [x for x in self.streamers if (x.baseurl, x.database) in [(url.split("#")[0], url.split("#")[1]) for url in self.conf["influxdb_url"]]]
 
   # Efficiency is calculated subtracting idletime per cpu from uptime.
   def _set_cpu_efficiency(self):
@@ -513,7 +514,7 @@ class Plancton(Daemon):
       except Exception as e:
         self.logctl.error("Cannot pull Docker image %s: no new containers, will retry later" % \
                           self.conf["docker_image"])
-    if prev_influxdb_url != self.conf["influxdb_url"]:
+    if set(prev_influxdb_url).symmetric_difference(set(self.conf["influxdb_url"])):
       self._influxdb_setup()
     running = self._count_containers()
     self.logctl.debug("CPU used: %.2f%%, available: %.2f%%" % (self.efficiency, self.idle))

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -224,10 +224,10 @@ class Plancton(Daemon):
     if isinstance(self.conf["influxdb_url"], list):
       for i,j in enumerate(self.conf["influxdb_url"]):
         baseurl,db = self.conf["influxdb_url"][j].split("#")
-        self.streamers[i] = InfluxDBStreamer(baseurl=baseurl, database=db)
+        self.streamers.append(InfluxDBStreamer(baseurl=baseurl, database=db))
     else:
       baseurl,db = self.conf["influxdb_url"].split("#")
-      self.streamers[0] = InfluxDBStreamer(baseurl=baseurl, database=db)
+      self.streamers.append(InfluxDBStreamer(baseurl=baseurl, database=db))
 
   # Efficiency is calculated subtracting idletime per cpu from uptime.
   def _set_cpu_efficiency(self):

--- a/plancton/__init__.py
+++ b/plancton/__init__.py
@@ -221,7 +221,7 @@ class Plancton(Daemon):
 
   # Set up monitoring target.
   def _influxdb_setup(self):
-    self.streamers = set()
+    self.streamers = set([ x for x in self.streamers if x.baseurl+"#"+x.database in self.conf["influxdb_url"] ])
     for url in self.conf["influxdb_url"]:
       self.streamers.add(InfluxDBStreamer(**dict(zip(["baseurl", "database"], url.split("#", 1)))))
 

--- a/plancton/influxdb_streamer.py
+++ b/plancton/influxdb_streamer.py
@@ -55,3 +55,10 @@ class InfluxDBStreamer():
       self.logctl.error("Error sending data: %s" % e)
       self.db_is_created = False
       return False
+
+  def __hash__(self):
+    return hash(self.baseurl + "#" + self.database)
+
+  def __eq__(self, rh):
+    return self.baseurl == rh.baseurl and self.database == rh.database
+

--- a/plancton/influxdb_streamer.py
+++ b/plancton/influxdb_streamer.py
@@ -22,7 +22,8 @@ class InfluxDBStreamer():
       r = requests.get(self.baseurl + "/query",
                        headers=self._headers_query,
                        params={ "q": "CREATE DATABASE \"%s\"" % self.database,
-                                "db": self.database })
+                                "db": self.database },
+                       timeout=5)
       self.logctl.debug("Creating database %s returned %d" % (self.database, r.status_code))
       r.raise_for_status()
       self.db_is_created = True
@@ -47,7 +48,8 @@ class InfluxDBStreamer():
       r = requests.post(self.baseurl+"/write",
                         headers=self._headers_write,
                         params={ "db": self.database },
-                        data=data_string.encode("utf-8"))
+                        data=data_string.encode("utf-8"),
+                        timeout=5)
       self.logctl.debug("Sending data returned %d" % r.status_code)
       r.raise_for_status()
       return True


### PR DESCRIPTION
- Backwards compatibility preserved for old configurations, where`influxdb_url` is a string.
- `influxdb_url` is accepted if as a list of URLs
- Plancton now loops over a set of streamers
- InfluxDB instances are run as container for tests   
