### PR TITLE
Allow optional insecure HTTPS for InfluxDB queries

### DIFF
--- a/plancton/influxdb_streamer.py
+++ b/plancton/influxdb_streamer.py
@@ -9,6 +9,12 @@ from datetime import datetime
 class InfluxDBStreamer():
   __version__ = "0.1"
   def __init__(self, baseurl, database):
+    if baseurl.startswith("insecure_https:"):
+      self.ssl_verify = False
+      self.real_baseurl = baseurl[9:]
+    else:
+      self.ssl_verify = True
+      self.real_baseurl = baseurl
     self.baseurl = baseurl
     self.database = database
     self.logctl = logging.getLogger("influxdb_streamer")
@@ -19,11 +25,12 @@ class InfluxDBStreamer():
   def create_db(self):
     try:
       self.logctl.debug("Creating database: %s" % self.database)
-      r = requests.get(self.baseurl + "/query",
+      r = requests.get(self.real_baseurl + "/query",
                        headers=self._headers_query,
                        params={ "q": "CREATE DATABASE \"%s\"" % self.database,
                                 "db": self.database },
-                       timeout=5)
+                       timeout=5,
+                       verify=self.ssl_verify)
       self.logctl.debug("Creating database %s returned %d" % (self.database, r.status_code))
       r.raise_for_status()
       self.db_is_created = True
@@ -45,11 +52,12 @@ class InfluxDBStreamer():
     self.logctl.debug("Sending line to database %s: %s" % (self.database, data_string))
 
     try:
-      r = requests.post(self.baseurl+"/write",
+      r = requests.post(self.real_baseurl+"/write",
                         headers=self._headers_write,
                         params={ "db": self.database },
                         data=data_string.encode("utf-8"),
-                        timeout=5)
+                        timeout=5,
+                        verify=self.ssl_verify)
       self.logctl.debug("Sending data returned %d" % r.status_code)
       r.raise_for_status()
       return True
@@ -63,4 +71,3 @@ class InfluxDBStreamer():
 
   def __eq__(self, rh):
     return self.baseurl == rh.baseurl and self.database == rh.database
-


### PR DESCRIPTION
Enabled by using `insecure_https://` as protocol instead of `https://`.